### PR TITLE
feat(flowers): petal burst on each tap-to-plant

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,87 @@
+// React 19's `TestRenderer.create()` schedules the initial render
+// asynchronously via the scheduler, so reading `.root` synchronously
+// afterwards finds an unmounted tree. Wrapping every call in act() works,
+// but our component tests use the natural synchronous shape:
+//
+//   const tree = TestRenderer.create(<X />);
+//   expect(tree.root.findAllByType(...))...
+//
+// To make that shape work, we patch `TestRenderer.create` to auto-wrap
+// its body in act(), so the initial render commits before returning.
+// Tests that explicitly drive async effects can still call act() manually
+// — nested act() is supported.
+{
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const TestRenderer = require('react-test-renderer');
+  const { act } = TestRenderer;
+  const originalCreate = TestRenderer.create;
+  TestRenderer.create = function autoActCreate(...args) {
+    let result;
+    act(() => {
+      result = originalCreate.apply(this, args);
+    });
+    return result;
+  };
+  // Also keep IS_REACT_ACT_ENVIRONMENT true (default) so legitimate
+  // unwrapped state updates still warn.
+}
+
+// Hand-written mock for react-native-reanimated v4.
+//
+// We deliberately avoid jest.requireActual('react-native-reanimated') and the
+// shipped 'react-native-reanimated/mock' — both re-import the real module,
+// which triggers react-native-worklets native init under jest and throws
+// "WorkletsError: [Worklets] Native part of Worklets doesn't seem to be initialized".
+//
+// We also avoid require('react-native') inside the factory: RN's index.js
+// uses lazy property getters that can fire after the Jest env is torn down
+// and crash the test. Instead, the mocked Animated.View is a tiny passthrough
+// React component that renders its children — sufficient for shallow tree
+// inspection via react-test-renderer.
+//
+// This mock covers the reanimated APIs used by:
+//   - src/components/PetalBurst.tsx
+//   - src/components/Flower.tsx
+jest.mock('react-native-reanimated', () => {
+  const React = require('react');
+
+  const AnimatedView = React.forwardRef(function AnimatedView(props, ref) {
+    return React.createElement('AnimatedView', { ...props, ref }, props.children);
+  });
+
+  const identity = (t) => t;
+  const fakeAnimation = (toValue, _config, callback) => {
+    if (typeof callback === 'function') callback(true);
+    return toValue;
+  };
+
+  const Easing = {
+    out: () => identity,
+    inOut: () => identity,
+    in: () => identity,
+    cubic: identity,
+    sin: identity,
+    linear: identity,
+    ease: identity,
+    quad: identity,
+    bezier: () => identity,
+  };
+
+  return {
+    __esModule: true,
+    default: { View: AnimatedView, createAnimatedComponent: (C) => C },
+    View: AnimatedView,
+    createAnimatedComponent: (C) => C,
+    useSharedValue: (init) => ({ value: init }),
+    useDerivedValue: (factory) => ({ value: factory() }),
+    useAnimatedStyle: (factory) => factory(),
+    runOnJS: (fn) => fn,
+    withTiming: fakeAnimation,
+    withSpring: fakeAnimation,
+    withDelay: (_delay, anim) => anim,
+    withRepeat: (anim) => anim,
+    withSequence: (...anims) => anims[anims.length - 1],
+    cancelAnimation: () => {},
+    Easing,
+  };
+});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ],
     "watchPathIgnorePatterns": [
       "<rootDir>/.worktrees/"
-    ]
+    ],
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"]
   },
   "dependencies": {
     "@expo/metro-runtime": "~56.0.11",
@@ -72,7 +73,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.2.14",
+    "@types/react-test-renderer": "^19.1.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "jest": "^29.2.1",
     "jest-expo": "~56.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "preset": "jest-expo",
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/.worktrees/"
+      "<rootDir>/.worktrees/"
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/.worktrees/"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,15 @@ importers:
       '@babel/core':
         specifier: ^7.26.10
         version: 7.29.0
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       '@types/react':
         specifier: ~19.2.14
         version: 19.2.15
+      '@types/react-test-renderer':
+        specifier: ^19.1.0
+        version: 19.1.0
       babel-plugin-module-resolver:
         specifier: ^5.0.0
         version: 5.0.3
@@ -1330,6 +1336,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
@@ -5697,6 +5706,11 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
 
   '@types/jsdom@20.0.1':
     dependencies:

--- a/src/components/FlowerField.tsx
+++ b/src/components/FlowerField.tsx
@@ -9,6 +9,7 @@ import { Platform } from 'react-native';
 
 const { width, height } = Dimensions.get('window');
 const FLOWER_TYPE_NAMES: FlowerType[] = ['rose', 'tulip', 'daisy', 'sunflower'];
+const MAX_CONCURRENT_BURSTS = 6;
 
 interface FlowerItem {
   id: string;
@@ -94,20 +95,25 @@ export const FlowerField = ({
       color: burstColor,
       type: newFlower.type,
     };
+    const atCap = flowers.length >= maxFlowers;
 
-    if (flowers.length >= maxFlowers) {
+    if (atCap) {
       setFlowers((prev) => [...prev.slice(1), newFlower]);
     } else {
       setFlowers((prev) => [...prev, newFlower]);
     }
 
-    setBursts((prev) => (prev.length >= 6 ? [...prev.slice(1), burst] : [...prev, burst]));
+    setBursts((prev) =>
+      prev.length >= MAX_CONCURRENT_BURSTS ? [...prev.slice(1), burst] : [...prev, burst]
+    );
 
-    if (onAddFlower) {
-      onAddFlower();
-    }
-    if (Platform.OS !== 'web') {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    if (!atCap) {
+      if (onAddFlower) {
+        onAddFlower();
+      }
+      if (Platform.OS !== 'web') {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      }
     }
   }, [flowers, isPremium, maxFlowers, onAddFlower]);
   

--- a/src/components/FlowerField.tsx
+++ b/src/components/FlowerField.tsx
@@ -2,12 +2,13 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { View, StyleSheet, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Flower } from './Flower';
-import { FlowerType } from './flowerData';
+import { PetalBurst } from './PetalBurst';
+import { flowerTypes, FlowerType } from './flowerData';
 import * as Haptics from 'expo-haptics';
 import { Platform } from 'react-native';
 
 const { width, height } = Dimensions.get('window');
-const flowerTypes: FlowerType[] = ['rose', 'tulip', 'daisy', 'sunflower'];
+const FLOWER_TYPE_NAMES: FlowerType[] = ['rose', 'tulip', 'daisy', 'sunflower'];
 
 interface FlowerItem {
   id: string;
@@ -18,6 +19,14 @@ interface FlowerItem {
     y: number;
   };
   color?: string;
+}
+
+interface BurstItem {
+  id: string;
+  x: number;
+  y: number;
+  color: string;
+  type: FlowerType;
 }
 
 interface FlowerFieldProps {
@@ -39,7 +48,8 @@ export const FlowerField = ({
 }: FlowerFieldProps) => {
   // State to track flowers
   const [flowers, setFlowers] = useState<FlowerItem[]>([]);
-  
+  const [bursts, setBursts] = useState<BurstItem[]>([]);
+
   // Generate initial flowers
   useEffect(() => {
     generateInitialFlowers();
@@ -64,7 +74,7 @@ export const FlowerField = ({
     
     return {
       id: Math.random().toString(),
-      type: flowerTypes[Math.floor(Math.random() * flowerTypes.length)],
+      type: FLOWER_TYPE_NAMES[Math.floor(Math.random() * FLOWER_TYPE_NAMES.length)],
       size: Math.random() * 30 + 45, // Size between 45-75
       position: { x: posX, y: posY },
       color: isPremium 
@@ -75,21 +85,29 @@ export const FlowerField = ({
   
   // Add a new flower when the user taps the screen
   const addFlower = useCallback((x: number, y: number) => {
+    const newFlower = createRandomFlower(x, y);
+    const burstColor = newFlower.color ?? flowerTypes[newFlower.type].defaultColor;
+    const burst: BurstItem = {
+      id: `burst-${newFlower.id}`,
+      x,
+      y,
+      color: burstColor,
+      type: newFlower.type,
+    };
+
     if (flowers.length >= maxFlowers) {
-      // Optional: Remove the oldest flower to make room for a new one
-      setFlowers(prev => [...prev.slice(1), createRandomFlower(x, y)]);
+      setFlowers((prev) => [...prev.slice(1), newFlower]);
     } else {
-      setFlowers(prev => [...prev, createRandomFlower(x, y)]);
-      
-      // Trigger the callback if provided
-      if (onAddFlower) {
-        onAddFlower();
-      }
-      
-      // Add haptic feedback for real devices
-      if (Platform.OS !== 'web') {
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-      }
+      setFlowers((prev) => [...prev, newFlower]);
+    }
+
+    setBursts((prev) => (prev.length >= 6 ? [...prev.slice(1), burst] : [...prev, burst]));
+
+    if (onAddFlower) {
+      onAddFlower();
+    }
+    if (Platform.OS !== 'web') {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     }
   }, [flowers, isPremium, maxFlowers, onAddFlower]);
   
@@ -119,6 +137,17 @@ export const FlowerField = ({
               // Make the flower "bloom" when tapped
               // This is handled inside the Flower component
             }}
+          />
+        ))}
+
+        {bursts.map((burst) => (
+          <PetalBurst
+            key={burst.id}
+            x={burst.x}
+            y={burst.y}
+            color={burst.color}
+            type={burst.type}
+            onComplete={() => setBursts((prev) => prev.filter((b) => b.id !== burst.id))}
           />
         ))}
       </View>

--- a/src/components/PetalBurst.tsx
+++ b/src/components/PetalBurst.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import Svg, { Path } from 'react-native-svg';
+import { flowerTypes, FlowerType } from './flowerData';
+
+const PARTICLE_COUNT = 8;
+const PARTICLE_SIZE = 18;
+const BASE_DURATION_MS = 400;
+const DURATION_JITTER_MS = 200;
+const MIN_DISTANCE_PX = 40;
+const MAX_DISTANCE_PX = 80;
+const FINAL_SCALE = 0.3;
+const ANGLE_JITTER_RAD = Math.PI / 16;
+
+type PetalBurstProps = {
+  x: number;
+  y: number;
+  color: string;
+  type: FlowerType;
+  onComplete: () => void;
+};
+
+type ParticleParams = {
+  angle: number;
+  distance: number;
+  rotation: number;
+  duration: number;
+  petalIndex: number;
+};
+
+const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
+
+const buildParticleParams = (petalCount: number): ParticleParams[] => {
+  return Array.from({ length: PARTICLE_COUNT }, (_, i) => ({
+    angle: (i / PARTICLE_COUNT) * Math.PI * 2 + randomBetween(-ANGLE_JITTER_RAD, ANGLE_JITTER_RAD),
+    distance: randomBetween(MIN_DISTANCE_PX, MAX_DISTANCE_PX),
+    rotation: randomBetween(-Math.PI * 2, Math.PI * 2),
+    duration: BASE_DURATION_MS + Math.random() * DURATION_JITTER_MS,
+    petalIndex: Math.floor(Math.random() * Math.max(petalCount, 1)),
+  }));
+};
+
+const Particle = ({
+  params,
+  color,
+  petalPath,
+  onDone,
+}: {
+  params: ParticleParams;
+  color: string;
+  petalPath: string;
+  onDone?: () => void;
+}) => {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withTiming(
+      1,
+      { duration: params.duration, easing: Easing.out(Easing.cubic) },
+      (finished) => {
+        if (finished && onDone) runOnJS(onDone)();
+      }
+    );
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const p = progress.value;
+    return {
+      opacity: 1 - p,
+      transform: [
+        { translateX: params.distance * Math.cos(params.angle) * p },
+        { translateY: params.distance * Math.sin(params.angle) * p },
+        { rotate: `${params.rotation * p}rad` },
+        { scale: 1 - (1 - FINAL_SCALE) * p },
+      ],
+    };
+  });
+
+  return (
+    <Animated.View
+      style={[
+        styles.particle,
+        { width: PARTICLE_SIZE, height: PARTICLE_SIZE },
+        animatedStyle,
+      ]}
+      pointerEvents="none"
+    >
+      <Svg width={PARTICLE_SIZE} height={PARTICLE_SIZE} viewBox="0 0 100 100">
+        <Path d={petalPath} fill={color} />
+      </Svg>
+    </Animated.View>
+  );
+};
+
+export const PetalBurst = ({ x, y, color, type, onComplete }: PetalBurstProps) => {
+  const flower = flowerTypes[type];
+  const petals = flower?.petals ?? [];
+  const paramsRef = useRef<ParticleParams[] | null>(null);
+  if (paramsRef.current === null) {
+    paramsRef.current = buildParticleParams(petals.length);
+  }
+
+  const longestIndex = paramsRef.current.reduce(
+    (best, p, i, arr) => (p.duration > arr[best].duration ? i : best),
+    0
+  );
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[styles.container, { left: x - PARTICLE_SIZE / 2, top: y - PARTICLE_SIZE / 2 }]}
+    >
+      {paramsRef.current.map((params, i) => (
+        <Particle
+          key={i}
+          params={params}
+          color={color}
+          petalPath={petals[params.petalIndex] ?? ''}
+          onDone={i === longestIndex ? onComplete : undefined}
+        />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    zIndex: 20,
+  },
+  particle: {
+    position: 'absolute',
+  },
+});

--- a/src/components/PetalBurst.tsx
+++ b/src/components/PetalBurst.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Animated, {
+  cancelAnimation,
   Easing,
   runOnJS,
   useAnimatedStyle,
@@ -59,15 +60,20 @@ const Particle = ({
   onDone?: () => void;
 }) => {
   const progress = useSharedValue(0);
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
 
   useEffect(() => {
     progress.value = withTiming(
       1,
       { duration: params.duration, easing: Easing.out(Easing.cubic) },
       (finished) => {
-        if (finished && onDone) runOnJS(onDone)();
+        if (finished && onDoneRef.current) runOnJS(onDoneRef.current)();
       }
     );
+    return () => {
+      cancelAnimation(progress);
+    };
   }, []);
 
   const animatedStyle = useAnimatedStyle(() => {

--- a/src/components/__tests__/PetalBurst.test.tsx
+++ b/src/components/__tests__/PetalBurst.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { Path } from 'react-native-svg';
+import { PetalBurst } from '../PetalBurst';
+
+describe('PetalBurst', () => {
+  it('renders 8 SVG Path particles, each tinted with the given color', () => {
+    const tree = TestRenderer.create(
+      <PetalBurst x={50} y={50} color="#FF0000" type="rose" onComplete={jest.fn()} />
+    );
+    const paths = tree.root.findAllByType(Path);
+    expect(paths).toHaveLength(8);
+    paths.forEach((p) => {
+      expect(p.props.fill).toBe('#FF0000');
+    });
+  });
+});

--- a/src/components/__tests__/PetalBurst.test.tsx
+++ b/src/components/__tests__/PetalBurst.test.tsx
@@ -5,13 +5,16 @@ import { PetalBurst } from '../PetalBurst';
 
 describe('PetalBurst', () => {
   it('renders 8 SVG Path particles, each tinted with the given color', () => {
+    const onComplete = jest.fn();
     const tree = TestRenderer.create(
-      <PetalBurst x={50} y={50} color="#FF0000" type="rose" onComplete={jest.fn()} />
+      <PetalBurst x={50} y={50} color="#FF0000" type="rose" onComplete={onComplete} />
     );
     const paths = tree.root.findAllByType(Path);
     expect(paths).toHaveLength(8);
     paths.forEach((p) => {
       expect(p.props.fill).toBe('#FF0000');
+      expect(p.props.d).toBeTruthy();
     });
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": ["jest", "react-test-renderer"],
     "paths": {
       "@/*": [
         "./*"


### PR DESCRIPTION
## Summary

When the user taps the sandbox to plant a flower, emit a short radial burst of 8 SVG petals from the tap point, tinted to match the planted flower's color. The whole moment lasts ~500ms and is one cohesive beat with the existing spring-in flower animation.

- New component: `src/components/PetalBurst.tsx` (Reanimated 4 + react-native-svg, 8 particles, UI-thread animated, self-cleans via `onComplete`)
- Wired into `src/components/FlowerField.tsx` as a parallel `bursts` state array, capped at `MAX_CONCURRENT_BURSTS = 6` (FIFO eviction)
- Preserves existing max-cap behavior: at 15 flowers (50 premium), oldest is replaced **silently** — counter does NOT increment and haptics do NOT fire (burst still fires per design)

## Test plan

- [x] `pnpm test` — 1/1 passing (structural test asserts 8 SVG Paths with correct fill + non-empty `d` + `onComplete` called once)
- [x] `pnpm typecheck` — exit 0
- [x] Web smoke test via Claude_Preview MCP — verified each tap adds +9 SVGs (1 flower + 8 burst), bursts self-remove at ~500-800ms, color cohesion (sunflower→yellow, tulip→coral, rose→red), and at-cap silent behavior
- [ ] **Pre-merge:** iOS-simulator tap-test (specifically: tap the 16th flower in free mode, confirm counter stays at 15, no haptic, burst still visible)
- [ ] Post-merge follow-up: add behavioral test for max-cap silent-replace rule (requires `@testing-library/react-native`)

## Background

- Design doc: [`docs/plans/2026-05-22-petal-burst-design.md`](docs/plans/2026-05-22-petal-burst-design.md)
- Implementation plan: [`docs/plans/2026-05-22-petal-burst.md`](docs/plans/2026-05-22-petal-burst.md)

Built via the `superpowers:subagent-driven-development` workflow: per-task implementer → spec reviewer → code-quality reviewer with re-review loops, plus a final whole-feature pass. Code-quality reviewer caught a critical regression baked into the plan (max-cap haptic/counter leak) which was fixed in commit `07865f6` before final review.

## Bundled changes

This PR also lands a small piece of test infrastructure (`a2b261a`) that the project needed before any jest test could run — `@types/jest`, `@types/react-test-renderer`, and a hand-written `react-native-reanimated` mock in `jest.setup.js`. A follow-up fix (`96c3ce1`) anchors `testPathIgnorePatterns` to `<rootDir>` so tests can be run from inside a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)